### PR TITLE
Add field-specific auto suggest

### DIFF
--- a/vendor/solr/server/solr/betapub/conf/solrconfig.xml
+++ b/vendor/solr/server/solr/betapub/conf/solrconfig.xml
@@ -1492,6 +1492,20 @@
       <str name="buildOnCommit">true</str>
       <str name="field">suggest</str>
     </lst>
+     <lst name="suggester">
+      <str name="name">authorSuggester</str>
+      <str name="lookupImpl">FuzzyLookupFactory</str>
+      <str name="suggestAnalyzerFieldType">textSuggest</str>
+      <str name="buildOnCommit">true</str>
+      <str name="field">authorsSearch</str>
+    </lst>
+     <lst name="suggester">
+      <str name="name">titleSuggester</str>
+      <str name="lookupImpl">FuzzyLookupFactory</str>
+      <str name="suggestAnalyzerFieldType">textSuggest</str>
+      <str name="buildOnCommit">true</str>
+      <str name="field">pubTitleIndex</str>
+    </lst>
   </searchComponent>
 
   <requestHandler name="/suggest" class="solr.SearchHandler" startup="lazy">


### PR DESCRIPTION
This works in solr, but blacklight doesn't know how to use it yet.

Add `&suggest.dictionary=titleSuggester` to `/suggest` to use the
pubTitleIndex for suggestions.

Add `&suggest.dictionary=autorSuggester` to `/suggest` to use the
authors index for suggestions.